### PR TITLE
github-calendar-parser 1.0.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 
-# github-calendar-parser [![PayPal](https://img.shields.io/badge/%24-paypal-f39c12.svg)][paypal-donations] [![Version](https://img.shields.io/npm/v/github-calendar-parser.svg)](https://www.npmjs.com/package/github-calendar-parser) [![Downloads](https://img.shields.io/npm/dt/github-calendar-parser.svg)](https://www.npmjs.com/package/github-calendar-parser) [![Get help on Codementor](https://cdn.codementor.io/badges/get_help_github.svg)](https://www.codementor.io/johnnyb?utm_source=github&utm_medium=button&utm_term=johnnyb&utm_campaign=github)
+# github-calendar-parser
+
+ [![PayPal](https://img.shields.io/badge/%24-paypal-f39c12.svg)][paypal-donations] [![AMA](https://img.shields.io/badge/ask%20me-anything-1abc9c.svg)](https://github.com/IonicaBizau/ama) [![Version](https://img.shields.io/npm/v/github-calendar-parser.svg)](https://www.npmjs.com/package/github-calendar-parser) [![Downloads](https://img.shields.io/npm/dt/github-calendar-parser.svg)](https://www.npmjs.com/package/github-calendar-parser) [![Get help on Codementor](https://cdn.codementor.io/badges/get_help_github.svg)](https://www.codementor.io/johnnyb?utm_source=github&utm_medium=button&utm_term=johnnyb&utm_campaign=github)
 
 > Parses the GitHub contributions calendar SVG code into JSON.
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "github-calendar-parser",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "Parses the GitHub contributions calendar SVG code into JSON.",
   "main": "lib/index.js",
   "directories": {
@@ -39,6 +39,7 @@
     "src/",
     "resources/",
     "menu/",
+    "scripts/",
     "cli.js",
     "index.js"
   ]


### PR DESCRIPTION
 - Updated the README.md following the new template. :memo:
 - Use [`babel-it`](https://github.com/IonicaBizau/babel-it) to babelify the code, so the module is now compatible with older versions of Node.js.