### PR TITLE
github-calendar-parser 1.1.5

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 
 # github-calendar-parser
 
- [![Patreon](https://img.shields.io/badge/Support%20me%20on-Patreon-%23e6461a.svg)][paypal-donations] [![PayPal](https://img.shields.io/badge/%24-paypal-f39c12.svg)][paypal-donations] [![AMA](https://img.shields.io/badge/ask%20me-anything-1abc9c.svg)](https://github.com/IonicaBizau/ama) [![Version](https://img.shields.io/npm/v/github-calendar-parser.svg)](https://www.npmjs.com/package/github-calendar-parser) [![Downloads](https://img.shields.io/npm/dt/github-calendar-parser.svg)](https://www.npmjs.com/package/github-calendar-parser) [![Get help on Codementor](https://cdn.codementor.io/badges/get_help_github.svg)](https://www.codementor.io/johnnyb?utm_source=github&utm_medium=button&utm_term=johnnyb&utm_campaign=github)
+ [![Patreon](https://img.shields.io/badge/Support%20me%20on-Patreon-%23e6461a.svg)][patreon] [![PayPal](https://img.shields.io/badge/%24-paypal-f39c12.svg)][paypal-donations] [![AMA](https://img.shields.io/badge/ask%20me-anything-1abc9c.svg)](https://github.com/IonicaBizau/ama) [![Version](https://img.shields.io/npm/v/github-calendar-parser.svg)](https://www.npmjs.com/package/github-calendar-parser) [![Downloads](https://img.shields.io/npm/dt/github-calendar-parser.svg)](https://www.npmjs.com/package/github-calendar-parser) [![Get help on Codementor](https://cdn.codementor.io/badges/get_help_github.svg)](https://www.codementor.io/johnnyb?utm_source=github&utm_medium=button&utm_term=johnnyb&utm_campaign=github)
 
 > Parses the GitHub contributions calendar SVG code into JSON.
 
@@ -88,6 +88,7 @@ Parses the SVG input (as string).
 
 ## :yum: How to contribute
 Have an idea? Found a bug? See [how to contribute][contributing].
+
 
 ## :moneybag: Donations
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "github-calendar-parser",
-  "version": "1.1.4",
+  "version": "1.1.5",
   "description": "Parses the GitHub contributions calendar SVG code into JSON.",
   "main": "lib/index.js",
   "directories": {
@@ -35,6 +35,7 @@
     "bin/",
     "app/",
     "lib/",
+    "build/",
     "dist/",
     "src/",
     "resources/",


### PR DESCRIPTION
 - Fix the [Patreon link](https://patreon.com/ionicabizau) in the README.md file. :memo: