### PR TITLE
Fix: the way to get fill data

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,22 +80,22 @@ var svg = `
         <svg width="722" height="112" class="js-calendar-graph-svg">
             <g transform="translate(10, 20)" data-hydro-click="{&quot;event_type&quot;:&quot;user_profile.click&quot;,&quot;payload&quot;:{&quot;profile_user_id&quot;:2864371,&quot;target&quot;:&quot;CONTRIBUTION_CALENDAR_SQUARE&quot;,&quot;user_id&quot;:null,&quot;originating_url&quot;:&quot;https://github.com/users/IonicaBizau/contributions&quot;}}" data-hydro-click-hmac="c29bb84527b62dafc7ab4208ed2db21ea4195839d541da829d109a8d172bee42">
                 <g transform="translate(0, 0)">
-                <rect class="day" width="10" height="10" x="14" y="0" fill="var(--color-calendar-graph-day-bg)" data-count="0" data-date="2019-11-03"/>
-                <rect class="day" width="10" height="10" x="14" y="13" fill="var(--color-calendar-graph-day-bg)" data-count="0" data-date="2019-11-04"/>
-                <rect class="day" width="10" height="10" x="14" y="26" fill="var(--color-calendar-graph-day-bg)" data-count="0" data-date="2019-11-05"/>
-                <rect class="day" width="10" height="10" x="14" y="39" fill="var(--color-calendar-graph-day-bg)" data-count="0" data-date="2019-11-06"/>
-                <rect class="day" width="10" height="10" x="14" y="52" fill="var(--color-calendar-graph-day-bg)" data-count="0" data-date="2019-11-07"/>
-                <rect class="day" width="10" height="10" x="14" y="65" fill="var(--color-calendar-graph-day-bg)" data-count="0" data-date="2019-11-08"/>
-                <rect class="day" width="10" height="10" x="14" y="78" fill="var(--color-calendar-graph-day-bg)" data-count="0" data-date="2019-11-09"/>
+                <rect class="ContributionCalendar-day" width="10" height="10" x="14" y="0" data-count="0" data-date="2019-11-03" data-level="0"/>
+                <rect class="ContributionCalendar-day" width="10" height="10" x="14" y="13" data-count="0" data-date="2019-11-04" data-level="0"/>
+                <rect class="ContributionCalendar-day" width="10" height="10" x="14" y="26" data-count="0" data-date="2019-11-05" data-level="0"/>
+                <rect class="ContributionCalendar-day" width="10" height="10" x="14" y="39" data-count="0" data-date="2019-11-06" data-level="0"/>
+                <rect class="ContributionCalendar-day" width="10" height="10" x="14" y="52" data-count="0" data-date="2019-11-07" data-level="0"/>
+                <rect class="ContributionCalendar-day" width="10" height="10" x="14" y="65" data-count="0" data-date="2019-11-08" data-level="0"/>
+                <rect class="ContributionCalendar-day" width="10" height="10" x="14" y="78" data-count="0" data-date="2019-11-09" data-level="0"/>
                 </g>
                 <g transform="translate(14, 0)">
-                    <rect class="day" width="10" height="10" x="13" y="0" fill="var(--color-calendar-graph-day-bg)" data-count="0" data-date="2019-11-10"/>
-                    <rect class="day" width="10" height="10" x="13" y="13" fill="var(--color-calendar-graph-day-L1-bg)" data-count="4" data-date="2019-11-11"/>
-                    <rect class="day" width="10" height="10" x="13" y="26" fill="var(--color-calendar-graph-day-bg)" data-count="0" data-date="2019-11-12"/>
-                    <rect class="day" width="10" height="10" x="13" y="39" fill="var(--color-calendar-graph-day-L1-bg)" data-count="1" data-date="2019-11-13"/>
-                    <rect class="day" width="10" height="10" x="13" y="52" fill="var(--color-calendar-graph-day-bg)" data-count="0" data-date="2019-11-14"/>
-                    <rect class="day" width="10" height="10" x="13" y="65" fill="var(--color-calendar-graph-day-bg)" data-count="0" data-date="2019-11-15"/>
-                    <rect class="day" width="10" height="10" x="13" y="78" fill="var(--color-calendar-graph-day-bg)" data-count="0" data-date="2019-11-16"/>
+                    <rect class="ContributionCalendar-day" width="10" height="10" x="13" y="0" data-count="0" data-date="2019-11-10" data-level="0"/>
+                    <rect class="ContributionCalendar-day" width="10" height="10" x="13" y="13" data-count="4" data-date="2019-11-11" data-level="1"/>
+                    <rect class="ContributionCalendar-day" width="10" height="10" x="13" y="26" data-count="0" data-date="2019-11-12" data-level="0"/>
+                    <rect class="ContributionCalendar-day" width="10" height="10" x="13" y="39" data-count="1" data-date="2019-11-13" data-level="1"/>
+                    <rect class="ContributionCalendar-day" width="10" height="10" x="13" y="52" data-count="0" data-date="2019-11-14" data-level="0"/>
+                    <rect class="ContributionCalendar-day" width="10" height="10" x="13" y="65" data-count="0" data-date="2019-11-15" data-level="0"/>
+                    <rect class="ContributionCalendar-day" width="10" height="10" x="13" y="78" data-count="0" data-date="2019-11-16" data-level="0"/>
                 </g>
             </g>
         </svg>

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,18 +1,6 @@
 "use strict";
 
-const githubCalendarLegend = require("github-calendar-legend")
-    , colorLegend = require("github-calendar-legend")
-    ;
-
-
-const GH_FILL_LEVELS = [
-    "day",
-    "day-L1",
-    "day-L4",
-    "day-L3",
-    "day-L2"
-]
-
+const colorLegend = require("github-calendar-legend")
 
 /**
  * parseGitHubCalendarSvg

--- a/lib/index.js
+++ b/lib/index.js
@@ -63,28 +63,27 @@ module.exports = function parseGitHubCalendarSvg (input) {
             return lastWeek.length && data.weeks.push(lastWeek) && (lastWeek = []);
         }
 
-        let fill = c.match(/fill="var\(\-\-color\-calendar\-graph\-([a-z0-9-]+)\-bg\)"/i)
+        let level = c.match(/data-level="([0-9\-]+)"/i)
           , date = c.match(/data-date="([0-9\-]+)"/)
           , count = c.match(/data-count="([0-9]+)"/)
-          , level = null
           ;
 
-        fill = fill && fill[1];
+        level = level && level[1];
         date = date && date[1];
         count = count && +count[1];
 
-        if (!fill) {
+        if (!level) {
             return;
         }
 
 
-        fill = colorLegend[GH_FILL_LEVELS.indexOf(fill)]
+        let fill = colorLegend[level]
 
         let obj = {
-            fill: fill
+            fill
           , date: new Date(date)
           , count: count
-          , level: githubCalendarLegend.indexOf(fill)
+          , level
         };
 
         if (data.current_streak === 0) {


### PR DESCRIPTION
Fix: #19 

## Problem

> `github-calendar-parser` get `fill` meta data, which is how many level a developer contributed on some day, by parsing `fill="var(--color-calendar-graph-day-L1-bg)"` attribute in the `<rect />`, but latest github calendar show `fill` data by `data-level` attribute, not `fill` attribute, so `github-calendar-parser` does not work now.

## Solution

I changed the way to get fill data from parsing `fill="var(--color-calendar-graph-day-L{level}-bg)"` to parsing `data-level="{level}"`

- [x] fix script
- [x] fix example in README