### PR TITLE
fix: contribution count parsing

### DIFF
--- a/example/index.js
+++ b/example/index.js
@@ -4,61 +4,73 @@ var svg = `
         <svg width="722" height="112" class="js-calendar-graph-svg">
             <g transform="translate(10, 20)" data-hydro-click="{&quot;event_type&quot;:&quot;user_profile.click&quot;,&quot;payload&quot;:{&quot;profile_user_id&quot;:2864371,&quot;target&quot;:&quot;CONTRIBUTION_CALENDAR_SQUARE&quot;,&quot;user_id&quot;:null,&quot;originating_url&quot;:&quot;https://github.com/users/IonicaBizau/contributions&quot;}}" data-hydro-click-hmac="c29bb84527b62dafc7ab4208ed2db21ea4195839d541da829d109a8d172bee42">
                 <g transform="translate(0, 0)">
-                <rect class="day" width="10" height="10" x="14" y="0" fill="var(--color-calendar-graph-day-bg)" data-count="0" data-date="2019-11-03"/>
-                <rect class="day" width="10" height="10" x="14" y="13" fill="var(--color-calendar-graph-day-bg)" data-count="0" data-date="2019-11-04"/>
-                <rect class="day" width="10" height="10" x="14" y="26" fill="var(--color-calendar-graph-day-bg)" data-count="0" data-date="2019-11-05"/>
-                <rect class="day" width="10" height="10" x="14" y="39" fill="var(--color-calendar-graph-day-bg)" data-count="0" data-date="2019-11-06"/>
-                <rect class="day" width="10" height="10" x="14" y="52" fill="var(--color-calendar-graph-day-bg)" data-count="0" data-date="2019-11-07"/>
-                <rect class="day" width="10" height="10" x="14" y="65" fill="var(--color-calendar-graph-day-bg)" data-count="0" data-date="2019-11-08"/>
-                <rect class="day" width="10" height="10" x="14" y="78" fill="var(--color-calendar-graph-day-bg)" data-count="0" data-date="2019-11-09"/>
+                    <rect width="10" height="10" x="14" y="0" class="ContributionCalendar-day" data-date="2022-01-09" data-level="0" rx="2" ry="2">2 contributions on January 9, 2022</rect>
+                    <rect width="10" height="10" x="14" y="13" class="ContributionCalendar-day" data-date="2022-01-10" data-level="0" rx="2" ry="2">15 contributions on January 10, 2022</rect>
+                    <rect width="10" height="10" x="14" y="26" class="ContributionCalendar-day" data-date="2022-01-11" data-level="0" rx="2" ry="2">No contributions on January 11, 2022</rect>
+                    <rect width="10" height="10" x="14" y="39" class="ContributionCalendar-day" data-date="2022-01-12" data-level="3" rx="2" ry="2">45 contributions on January 12, 2022</rect>
+                    <rect width="10" height="10" x="14" y="52" class="ContributionCalendar-day" data-date="2022-01-13" data-level="1" rx="2" ry="2">2 contributions on January 13, 2022</rect>
+                    <rect width="10" height="10" x="14" y="65" class="ContributionCalendar-day" data-date="2022-01-14" data-level="0" rx="2" ry="2">No contributions on January 14, 2022</rect>
+                    <rect width="10" height="10" x="14" y="78" class="ContributionCalendar-day" data-date="2022-01-15" data-level="0" rx="2" ry="2">1 contribution on January 15, 2022</rect>
                 </g>
                 <g transform="translate(14, 0)">
-                    <rect class="day" width="10" height="10" x="13" y="0" fill="var(--color-calendar-graph-day-bg)" data-count="0" data-date="2019-11-10"/>
-                    <rect class="day" width="10" height="10" x="13" y="13" fill="var(--color-calendar-graph-day-L1-bg)" data-count="4" data-date="2019-11-11"/>
-                    <rect class="day" width="10" height="10" x="13" y="26" fill="var(--color-calendar-graph-day-bg)" data-count="0" data-date="2019-11-12"/>
-                    <rect class="day" width="10" height="10" x="13" y="39" fill="var(--color-calendar-graph-day-L1-bg)" data-count="1" data-date="2019-11-13"/>
-                    <rect class="day" width="10" height="10" x="13" y="52" fill="var(--color-calendar-graph-day-bg)" data-count="0" data-date="2019-11-14"/>
-                    <rect class="day" width="10" height="10" x="13" y="65" fill="var(--color-calendar-graph-day-bg)" data-count="0" data-date="2019-11-15"/>
-                    <rect class="day" width="10" height="10" x="13" y="78" fill="var(--color-calendar-graph-day-bg)" data-count="0" data-date="2019-11-16"/>
+                    <rect width="10" height="10" x="13" y="0" class="ContributionCalendar-day" data-date="2022-01-16" data-level="1" rx="2" ry="2">6 contributions on January 16, 2022</rect>
+                    <rect width="10" height="10" x="13" y="13" class="ContributionCalendar-day" data-date="2022-01-17" data-level="0" rx="2" ry="2">No contributions on January 17, 2022</rect>
+                    <rect width="10" height="10" x="13" y="26" class="ContributionCalendar-day" data-date="2022-01-18" data-level="1" rx="2" ry="2">2 contributions on January 18, 2022</rect>
+                    <rect width="10" height="10" x="13" y="39" class="ContributionCalendar-day" data-date="2022-01-19" data-level="0" rx="2" ry="2">No contributions on January 19, 2022</rect>
+                    <rect width="10" height="10" x="13" y="52" class="ContributionCalendar-day" data-date="2022-01-20" data-level="1" rx="2" ry="2">4 contributions on January 20, 2022</rect>
+                    <rect width="10" height="10" x="13" y="65" class="ContributionCalendar-day" data-date="2022-01-21" data-level="1" rx="2" ry="2">1 contribution on January 21, 2022</rect>
+                    <rect width="10" height="10" x="13" y="78" class="ContributionCalendar-day" data-date="2022-01-22" data-level="0" rx="2" ry="2">No contributions on January 22, 2022</rect>
                 </g>
             </g>
         </svg>
 `;
 
 console.log(parse(svg))
+
 // {
-//     "last_year": 5,
-//     "longest_streak": 1,
-//     "longest_streak_range": ["2019-11-11T00:00:00.000Z", "2019-11-11T00:00:00.000Z"],
-//     "current_streak": 0,
-//     "current_streak_range": ["2019-11-16T00:00:00.000Z", "2019-11-13T00:00:00.000Z"],
-//     "weeks": [
-//         [{
-//             "fill": "#eee",
-//             "date": "2019-11-03T00:00:00.000Z",
-//             "count": 0,
-//             "level": 0
-//         },
-//         ...
-//         {
-//             "fill": "#eee",
-//             "date": "2019-11-09T00:00:00.000Z",
-//             "count": 0,
-//             "level": 0
-//         }]
-//     ],
-//     "days": [{
-//         "fill": "#eee",
-//         "date": "2019-11-03T00:00:00.000Z",
-//         "count": 0,
-//         "level": 0
-//     },
-//     ...
-//     {
-//         "fill": "#eee",
-//         "date": "2019-11-16T00:00:00.000Z",
-//         "count": 0,
-//         "level": 0
-//     }],
-//     "last_contributed": "2019-11-13T00:00:00.000Z"
+  // last_year: 78,
+  // longest_streak: 2,
+  // longest_streak_range: [ 2022-01-09T00:00:00.000Z, 2022-01-10T00:00:00.000Z ],
+  // current_streak: 0,
+  // current_streak_range: [ 2022-01-20T00:00:00.000Z, 2022-01-21T00:00:00.000Z ],
+  // longest_break: 1,
+  // longest_break_range: [ 2022-01-11T00:00:00.000Z, 2022-01-11T00:00:00.000Z ],
+  // current_break: 1,
+  // current_break_range: [ 2022-01-22T00:00:00.000Z, 2022-01-22T00:00:00.000Z ],
+  // weeks: [
+    // [
+      // [Object], [Object],
+      // [Object], [Object],
+      // [Object], [Object],
+      // [Object]
+    // ]
+  // ],
+  // days: [
+    // {
+      // fill: '#eee',
+      // date: 2022-01-09T00:00:00.000Z,
+      // count: 2,
+      // level: '0'
+    // },
+    // {
+      // fill: '#eee',
+      // date: 2022-01-10T00:00:00.000Z,
+      // count: 15,
+      // level: '0'
+    // },
+    // ...
+    // {
+      // fill: '#d6e685',
+      // date: 2022-01-21T00:00:00.000Z,
+      // count: 1,
+      // level: '1'
+    // },
+    // {
+      // fill: '#eee',
+      // date: 2022-01-22T00:00:00.000Z,
+      // count: 0,
+      // level: '0'
+    // }
+  // ],
+  // last_contributed: 2022-01-21T00:00:00.000Z
 // }

--- a/lib/index.js
+++ b/lib/index.js
@@ -64,12 +64,15 @@ module.exports = function parseGitHubCalendarSvg (input) {
 
         let level = c.match(/data-level="([0-9\-]+)"/i)
           , date = c.match(/data-date="([0-9\-]+)"/)
-          , count = c.match(/data-count="([0-9]+)"/)
+          , count = c.match(/(No|[0-9]+)( contribution)/)
           ;
 
         level = level && level[1];
         date = date && date[1];
-        count = count && +count[1];
+        if (count)
+            if (count[1] === "No")
+                count[1] = 0
+            count = count && +count[1];
 
         if (!level) {
             return;


### PR DESCRIPTION
GitHub changed the formatting of their contribution graphs, so [github-calendar](https://github.com/Bloggify/github-calendar) does not show the correct number of contributions any more.

Some users have already noticed and opened [#157](https://github.com/Bloggify/github-calendar/issues/157).

GitHub has removed the `data-count` attribute in favour of a string containing the number of contributions as the content of the `rect` tag.

Therefore, the fix itself was quite simple.

I also updated the example SVG and the resulting abridged console log.